### PR TITLE
Adopt Node 26 for sandbox and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: 26
           cache: npm
       - run: npm ci
       - run: npm run lint:check

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: 26
           cache: npm
       - run: npm ci
       # VITE_ICINGA_API_URL comes from the committed .env (single source of truth).

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -6,9 +6,10 @@
 # carries none of your host secrets (no ~/.ssh, no ~/.npmrc, no credentials). So a malicious
 # postinstall executes against an empty box, not your keys.
 #
-# Base is the plain node:24 LTS tag (current LTS as of 2026). We trust the official Node
-# image tags — if those were compromised the blast radius is the whole ecosystem, not us.
-FROM node:24-bookworm-slim
+# Base is the plain node:26 tag (Node "Current"; goes Active LTS ~Oct 2026). We trust the
+# official Node image tags — if those were compromised the blast radius is the whole
+# ecosystem, not us.
+FROM node:26-bookworm-slim
 
 # Point HOME and the package-manager caches at a writable tmpfs, because sandbox.sh mounts
 # the root filesystem read-only at runtime. The image already ships a non-root `node` user


### PR DESCRIPTION
Moves the dev sandbox base image (`docker/Dockerfile.dev`) and the CI/deploy `node-version` from **24 → 26**.

Node 26 is currently **"Current"** (becomes Active LTS ~Oct 2026). Verified the full stack on it in the sandbox before bumping:

- `npm ci`, `npm audit` (0 vulnerabilities), lint, and build all pass.
- Headless Chrome render against the live API: all 4 hosts / 59 service rows — identical to Node 24.
- esbuild/rollup native binaries are platform-specific (linux-x64), not Node-version-specific, so nothing needed rebuilding.

Supersedes dependabot #71 (which only bumped the Dockerfile) — that PR can be closed once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)