### PR TITLE
Center the About card within the page

### DIFF
--- a/src/views/AboutView.vue
+++ b/src/views/AboutView.vue
@@ -20,6 +20,7 @@
 <style scoped>
 .about {
   max-width: 640px;
+  margin: 0 auto;
   padding: 1.5rem 1.75rem;
   background: var(--card);
   border: 1px solid var(--border);


### PR DESCRIPTION
Tiny fix: the About card was capped at 640px with no horizontal margin, so it sat against the left edge of the centered 1100px container (visible as off-center on `/about`). Adds `margin: 0 auto` to center it.

Verified with a headless render — card now centers and lines up with the footer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)